### PR TITLE
Fixes disqus evaluation errors

### DIFF
--- a/layouts/partials/disqus.html
+++ b/layouts/partials/disqus.html
@@ -3,7 +3,7 @@
 
 <script type="text/javascript">
     /* * * CONFIGURATION VARIABLES * * */
-    var disqus_shortname = '{{ .Site.DisqusShortname }}';
+    var disqus_shortname = '{{ $.Site.DisqusShortname }}';
 
     /* * * DON'T EDIT BELOW THIS LINE * * */
     (function() {


### PR DESCRIPTION
When discusShortname is set I get this error:

> ERROR: 2016/05/08 12:08:59 template.go:119: template: theme/partials/disqus.html:6:36: executing "theme/partials/disqus.html" at <.Site.DisqusShortnam...>: can't evaluate field Site in type string in theme/partials/disqus.html

( Tested with hugo v0.15 )
