### PR TITLE
change relative path to css and js 

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -11,7 +11,7 @@
 
 </div>
 
-<script src="/js/highlight.pack.js"></script>
+<script src="{{ .Site.BaseURL }}js/highlight.pack.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 
 {{ with .Site.Params.analytics }}<script>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -21,11 +21,11 @@
 
   <!-- CSS
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-  <link rel="stylesheet" href="/css/sanitize.css">
-  <link rel="stylesheet" href="/css/responsive.css">
-  <link rel="stylesheet" href="/css/highlight_monokai.css">
-  <link rel="stylesheet" href="/css/theme.css">
-  <link rel="stylesheet" href="/css/custom.css">
+  <link rel="stylesheet" href="{{ .Site.BaseURL }}css/sanitize.css">
+  <link rel="stylesheet" href="{{ .Site.BaseURL }}css/responsive.css">
+  <link rel="stylesheet" href="{{ .Site.BaseURL }}css/highlight_monokai.css">
+  <link rel="stylesheet" href="{{ .Site.BaseURL }}css/theme.css">
+  <link rel="stylesheet" href="{{ .Site.BaseURL }}css/custom.css">
   
   <!-- RSS
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->


### PR DESCRIPTION
In `header.html` and `footer.html`, currently the path to css and js are fixed as relative path from doc root dir. This p-r fixes them to the ones from `.Site.BaseURL`.
