### PR TITLE
Adds Facebook OpenGraph <meta> tags in header.html to specify og:image

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -42,13 +42,11 @@
 
   <!-- Facebook OpenGraph
   –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-  {{if .Params.image }}
-     <meta property="og:image" content="{{ .Site.BaseURL }}images/{{.Params.image}}"/>
-  {{else}}
-      {{if .Site.Params.cover}}
-          <meta property="og:image" content="{{ .Site.BaseURL }}images/{{.Site.Params.cover}}"/>
-      {{end}}
-  {{end}}
+  {{ if .Params.image }}
+    <meta property="og:image" content="{{ .Site.BaseURL }}images/{{ .Params.image }}"/>
+  {{ else if .Site.Params.cover }}
+    <meta property="og:image" content="{{ .Site.BaseURL }}images/{{ .Site.Params.cover }}"/>
+  {{ end }}
 
 
 </head>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -40,6 +40,16 @@
     <script type="text/javascript">stLight.options({publisher: '{{ . }}', doNotHash: true, doNotCopy: true, hashAddressBar: false});</script>
   {{ end }}
 
+  <!-- Facebook OpenGraph
+  –––––––––––––––––––––––––––––––––––––––––––––––––– -->
+  {{if .Params.image }}
+     <meta property="og:image" content="{{ .Site.BaseURL }}images/{{.Params.image}}"/>
+  {{else}}
+      {{if .Site.Params.cover}}
+          <meta property="og:image" content="{{ .Site.BaseURL }}images/{{.Site.Params.cover}}"/>
+      {{end}}
+  {{end}}
+
 
 </head>
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -47,6 +47,9 @@
   {{ else if .Site.Params.cover }}
     <meta property="og:image" content="{{ .Site.BaseURL }}images/{{ .Site.Params.cover }}"/>
   {{ end }}
+  {{ if .Params.description }}
+    <meta property="og:description" content="{{ .Params.description }}"/>
+  {{ end }}
 
 
 </head>


### PR DESCRIPTION
Pulls value for `og:image` from value for `image` in blog post's `.md' file or from value for`cover` in config.toml.
