### PR TITLE
 Make it possible to hide Google Analytics tags in the development mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ Please change the favorite color.
 
 For original styles, please edit the `layouts/static/custom.css`.
 
+## Development Mode
+
+ Development mode is supported. In this mode, Google Analytics tags are not rendered.
+
+```
+env HUGO_ENV="DEV" hugo server -t angels-ladder -D -w
+```
 
 ## License
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -14,6 +14,7 @@
 <script src="/js/highlight.pack.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 
+{{ if ne (getenv "HUGO_ENV") "DEV" }}
 {{ with .Site.Params.analytics }}<script>
 	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -22,6 +23,7 @@
 	ga('create', '{{ . }}', 'auto');
 	ga('send', 'pageview');
 </script>{{ end }}
+{{ end }}
 
 </body>
 </html>


### PR DESCRIPTION
 Add a development mode, in which Google Analytics tags are not shown. 

You can use development mode by environmental variable `HUGO_ENV` like this. 

```
env HUGO_ENV="DEV" hugo server -t angels-ladder -D -w
```

This idea comes from another hugo-theme [hugo_theme_robust](https://github.com/dim0627/hugo_theme_robust#development-mode) :-D
